### PR TITLE
allow .yamllint path/filename to be customized

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -10,9 +10,9 @@ export default {
     },
     useProjectConfig: {
       title: 'Use project yamllint config file.',
-      type: 'boolean',
-      description: 'Use an yamllint configuration file named `.yamllint` in the root level of the project directory. Overrides other settings besides executable path and blacklist.',
-      default: false,
+      type: 'string',
+      description: 'Use a yamllint configuration file (e.g. .yamllint). Path is relative to the root level of the project directory. Overrides other settings besides executable path and blacklist.',
+      default: 'none',
     },
     timeout: {
       title: 'Linting Timeout',
@@ -45,10 +45,10 @@ export default {
         var args = ['-f', 'parsable']
 
         // use config file if specified
-        if (atom.config.get('linter-yaml.useProjectConfig')) {
+        if (atom.config.get('linter-yaml.useProjectConfig') !== 'none') {
           // cannot cwd in project path and then add file relative path to args because ansible relies on pathing relative to directory execution for includes
           const project_path = atom.project.relativizePath(file)[0];
-          const configPath = project_path + '/.yamllint'
+          const configPath = project_path + '/' + atom.config.get('linter-yaml.useProjectConfig')
           configExists = fs.existsSync(configPath)
 
           if (configExists) {


### PR DESCRIPTION
my yamllint config ends up being in a subdir and with a different name, `ansible/.yamllint.yml`, so this makes the config a bit more flexible

Happy to tweak anything or bump version etc just let me know, thanks for building this package!